### PR TITLE
Fix params/await & hydration error

### DIFF
--- a/src/app/bills/[id]/page.tsx
+++ b/src/app/bills/[id]/page.tsx
@@ -11,20 +11,22 @@ import {
 import { Separator } from "@/components/ui/separator";
 
 interface Params {
-  params: { id: string };
+  params: Promise<{ id: string }>;
 }
 
 
 
 export default async function BillDetail({ params }: Params) {
+  const { id } = await params;
+
   // Try database first, then fallback to API
-  const dbBill = await getBillByIdFromDB(params.id);
+  const dbBill = await getBillByIdFromDB(id);
   let unifiedBill: UnifiedBill | null = null;
 
   if (dbBill) {
     unifiedBill = fromDbBill(dbBill);
   } else {
-    const apiBill = await getBillFromApi(params.id);
+    const apiBill = await getBillFromApi(id);
     if (apiBill) {
       unifiedBill = await fromApiBill(apiBill);
     }

--- a/src/components/BillCard.tsx
+++ b/src/components/BillCard.tsx
@@ -15,7 +15,12 @@ interface BillCardProps {
 }
 
 export default function BillCard({ bill }: BillCardProps) {
-  const updatedAt = new Date(bill.lastUpdatedOn);
+
+  const updatedAt = bill.lastUpdatedOn ? new Date(bill.lastUpdatedOn) : null;
+  const formattedDate = updatedAt && !isNaN(updatedAt.getTime())
+    ? updatedAt.toISOString().split('T')[0]
+    : null;
+  const dateDisplay = formattedDate ? `Updated ${formattedDate}` : 'Bill not processed';
 
   return (
     <li className="group rounded-lg border   bg-[var(--panel)] shadow-sm   duration-200 overflow-hidden">
@@ -95,7 +100,7 @@ export default function BillCard({ bill }: BillCardProps) {
                 <span>by {bill.sponsorName}</span>
               )}
             </div>
-            <span className="text-[var(--muted-foreground)]">Updated {updatedAt.toLocaleDateString()}</span>
+            <span className="text-[var(--muted-foreground)]">{dateDisplay}</span>
           </div>
         </div>
       </Link>


### PR DESCRIPTION
This fixes two errors I ran into

1.`params` not being awaited in `src/app/bills/[id]/page.tsx`
2. A hydration error in `src/components/BillCard.tsx`. I made a decision here to either show `Updated ${date}` or `Bill not processed`. Easy to change this if desired.